### PR TITLE
docs: トランクベース開発のプロモーションモデルを明記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,24 @@ Firebase ID token in Authorization header -> server-side verification.
 - Local DB: Drift (SQLite)
 - API: REST
 
+### Branching Strategy
+
+This repository follows **Trunk-Based Development**.
+
+**Promotion flow:**
+
+```
+feature branch --> PR --> main (trunk)
+```
+
+**Branch lifecycle:**
+
+- [MUST] Keep feature branches short-lived (merge within days, not weeks)
+- [MUST] Branch from `main` and merge back to `main` via PR
+- [MUST] Delete feature branches after merge
+- [Forbidden] Long-lived development branches (e.g., `develop`, `release/*`)
+- [Forbidden] Direct push to `main` -- all changes go through PR
+
 ## Quality Standards
 
 See [docs/golden-principles.md](docs/golden-principles.md) for the quality principles all documents must satisfy.

--- a/README.md
+++ b/README.md
@@ -233,12 +233,18 @@ melos run deps:validate
 
 ### 開発フロー
 
-1. **Issue 作成** - 作業内容を明確化
-2. **ブランチ作成** - `feature/GH-{issue 番号}`
-3. **実装** - TDD（Red -> Green -> Refactor）
-4. **テスト** - Unit / Widget / Integration テスト
-5. **PR 作成** - レビュー依頼
-6. **マージ** - マージコミットで統合
+このリポジトリは **Trunk-Based Development** を採用している。`main` ブランチを常にリリース可能な状態に保ち、短命のフィーチャーブランチで開発を行う。
+
+```
+feature branch --> PR --> main (trunk)
+```
+
+1. **Issue 作成** -- 作業内容を明確化
+2. **ブランチ作成** -- `feature/GH-{issue 番号}` を `main` から作成
+3. **実装** -- TDD (Red -> Green -> Refactor)
+4. **テスト** -- Unit / Widget / Integration テスト
+5. **PR 作成** -- レビュー依頼
+6. **マージ** -- main にマージ後、フィーチャーブランチを削除
 
 ## アーキテクチャ
 


### PR DESCRIPTION
## Summary

- AGENTS.md に Branching Strategy セクションを追加し、Trunk-Based Development のプロモーションフロー (`feature branch --> PR --> main`) とブランチライフサイクルルールを明記
- README.md の「開発フロー」セクションを更新し、Trunk-Based Development の採用を明示。プロモーションモデル図と各ステップの説明を改善

## Why

ブランチ戦略が暗黙知のままだったため、AI エージェント向け (AGENTS.md) と人間向け (README.md) の両方で Trunk-Based Development モデルを明文化し、開発フローの認識を統一する。

## Test plan

- [ ] AGENTS.md の Branching Strategy セクションが正しくレンダリングされることを確認
- [ ] README.md の開発フローセクションが正しくレンダリングされることを確認
- [ ] `bun run format` / `bun run lint:docs` がパスすることを確認