### PR TITLE
ci: ARM64 ランナー移行と CI キャッシュ最適化

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -18,9 +18,9 @@ runs:
         path: |
           ~/.bun/install/cache
           node_modules
-        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
         restore-keys: |
-          bun-${{ runner.os }}-
+          bun-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-flutter-workspace/action.yml
+++ b/.github/actions/setup-flutter-workspace/action.yml
@@ -25,7 +25,19 @@ runs:
           ~/.pub-cache/git
         key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pubspec.lock') }}
 
+    # グローバルパッケージ (melos, bloc_tools) のキャッシュ
+    # バージョンが変わらない限り再インストールをスキップ (推定 10-20s 短縮)
+    - name: Cache global packages
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          ~/.pub-cache/bin
+          ~/.pub-cache/global_packages
+        key: pub-global-${{ runner.os }}-${{ runner.arch }}-melos-${{ hashFiles('pubspec.lock') }}-bloc-tools-0.1.0-dev.20
+
+    # macOS のみ: Swift Package Manager を有効化 (Linux CI では不要)
     - name: Enable Swift Package Manager
+      if: runner.os == 'macOS'
       shell: bash
       run: flutter config --enable-swift-package-manager
 

--- a/.github/actions/setup-flutter-workspace/action.yml
+++ b/.github/actions/setup-flutter-workspace/action.yml
@@ -15,6 +15,14 @@ runs:
         echo "PUB_CACHE=$HOME/.pub-cache" >> "$GITHUB_ENV"
         echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
 
+    - name: Resolve tool versions
+      id: versions
+      shell: bash
+      run: |
+        MELOS_VERSION=$(yq ".packages.melos.version" -r < pubspec.lock)
+        echo "melos=$MELOS_VERSION" >> "$GITHUB_OUTPUT"
+        echo "bloc-tools=0.1.0-dev.20" >> "$GITHUB_OUTPUT"
+
     # restore-keys を使用しない: 古いキャッシュ復元による依存関係の不整合を防止
     # --enforce-lockfile との一貫性を保つため、常に現在の lockfile と完全一致するキャッシュのみ使用
     - name: Cache pub packages
@@ -33,7 +41,7 @@ runs:
         path: |
           ~/.pub-cache/bin
           ~/.pub-cache/global_packages
-        key: pub-global-${{ runner.os }}-${{ runner.arch }}-melos-${{ hashFiles('pubspec.lock') }}-bloc-tools-0.1.0-dev.20
+        key: pub-global-${{ runner.os }}-${{ runner.arch }}-melos-${{ steps.versions.outputs.melos }}-bloc-tools-${{ steps.versions.outputs.bloc-tools }}
 
     # macOS のみ: Swift Package Manager を有効化 (Linux CI では不要)
     - name: Enable Swift Package Manager
@@ -44,10 +52,9 @@ runs:
     - name: Setup melos
       shell: bash
       run: |
-        MELOS_VERSION=$(cat pubspec.lock | yq ".packages.melos.version" -r)
-        flutter pub global activate melos "$MELOS_VERSION"
+        flutter pub global activate melos "${{ steps.versions.outputs.melos }}"
         melos bootstrap --enforce-lockfile
 
     - name: Activate bloc_tools
       shell: bash
-      run: dart pub global activate bloc_tools 0.1.0-dev.20
+      run: dart pub global activate bloc_tools "${{ steps.versions.outputs.bloc-tools }}"

--- a/.github/workflows/_changes.yml
+++ b/.github/workflows/_changes.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   detect-changes:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/doc-gc.yml
+++ b/.github/workflows/doc-gc.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   freshness-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read
@@ -86,7 +86,7 @@ jobs:
             }
 
   quality-score:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/doc-gc.yml
+++ b/.github/workflows/doc-gc.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        env:
+          MISE_DISABLE_TOOLS: flutter,java,ruby,gem:cocoapods
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
@@ -109,6 +111,8 @@ jobs:
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
         with:
           github_api_token: ${{ steps.app-token.outputs.token }}
+        env:
+          MISE_DISABLE_TOOLS: flutter,java,ruby,gem:cocoapods
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/pr-assign-author.yml
+++ b/.github/workflows/pr-assign-author.yml
@@ -24,7 +24,7 @@ jobs:
   assign-author:
     if: ${{ !contains(github.actor, '[bot]') }}
     name: Assign author to PR
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Create GitHub App Token

--- a/.github/workflows/pr-block-merge.yml
+++ b/.github/workflows/pr-block-merge.yml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   block-merge-labels:
     name: Block Merge Labels
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 1
     steps:
       - name: Check for blocking labels
@@ -45,7 +45,7 @@ jobs:
 
   gate:
     name: Block Merge
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 1
     needs:
       - block-merge-labels

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,8 +41,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # arm64 未対応ツール (Flutter, CocoaPods 等) を除外
       - name: Setup mise
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        env:
+          MISE_DISABLE_TOOLS: flutter,java,ruby,gem:cocoapods
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@e58ee9d111489c31395fbe4857b0be6e7635dbda # v1.70.0
@@ -66,6 +69,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        env:
+          MISE_DISABLE_TOOLS: flutter,java,ruby,gem:cocoapods
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
@@ -88,6 +93,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        env:
+          MISE_DISABLE_TOOLS: flutter,java,ruby,gem:cocoapods
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/_changes.yml
 
   actionlint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: needs.changes.outputs.ci == 'true'
     timeout-minutes: 5
@@ -52,7 +52,7 @@ jobs:
           reporter: github-pr-review
 
   format:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: needs.changes.outputs.format == 'true'
     timeout-minutes: 5
@@ -74,7 +74,7 @@ jobs:
         run: bun run format
 
   doc-lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: needs.changes.outputs.docs == 'true'
     timeout-minutes: 5
@@ -159,7 +159,7 @@ jobs:
 
   gate:
     name: Checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 1
     needs:
       - actionlint

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Run document structure lint
         run: bun run lint:docs
 
+  # x64 必須: Flutter SDK が arm64 Linux ホストを未サポート
   analyze:
     runs-on: ubuntu-24.04
     needs: changes
@@ -126,6 +127,7 @@ jobs:
       - name: Run analyze
         run: melos run analyze --no-select
 
+  # x64 必須: Flutter SDK が arm64 Linux ホストを未サポート
   test:
     runs-on: ubuntu-24.04
     needs: changes

--- a/.github/workflows/pr-semantic.yml
+++ b/.github/workflows/pr-semantic.yml
@@ -27,7 +27,7 @@ defaults:
 jobs:
   semantic-pull-request:
     name: Semantic Pull Request
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Create GitHub App Token
@@ -43,7 +43,7 @@ jobs:
 
   gate:
     name: Semantic
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 1
     needs:
       - semantic-pull-request

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   sync:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- copilot:reviewCommentLanguage=ja -->

## チケット

- close #6

## Why

全 CI ワークフローが `ubuntu-24.04` (x64) で実行されており、Public リポジトリで無料利用可能な ARM64 ランナー (`ubuntu-24.04-arm`, Cobalt 100, 最大 40% 高速) を活用していなかった。また、キャッシュ戦略に改善余地があった。

## What

### As Is

- 全ジョブが `ubuntu-24.04` (x64, 4vCPU/16GB) で実行
- `setup-bun` のキャッシュキーに `runner.arch` が含まれていない
- グローバルパッケージ (melos, bloc_tools) がキャッシュされていない
- `flutter config --enable-swift-package-manager` が Linux CI でも実行されている

### To Be

- Flutter 非依存の軽量ジョブ (13ジョブ) が `ubuntu-24.04-arm` (ARM64) で実行
  - `_changes.yml`, `pr-checks.yml` (actionlint/format/doc-lint/gate),
    `pr-assign-author.yml`, `pr-block-merge.yml`, `pr-semantic.yml`,
    `sync-labels.yml`, `doc-gc.yml`
- Flutter 依存ジョブ (analyze, test) と `srvaroa/labeler` (pr-labeler) は x64 を維持
  - Flutter SDK: arm64 Linux stable ビルド未提供
  - srvaroa/labeler: amd64 Go バイナリのみ
- `setup-bun` のキャッシュキーに `runner.arch` を追加 (x64/ARM64 キャッシュ分離)
- グローバルパッケージキャッシュを追加 (推定 10-20s 短縮)
- `flutter config --enable-swift-package-manager` を macOS のみに条件化
- ツールバージョンを `versions` ステップで一元管理

## How

ARM64 互換性は事前調査で確認済み:
- `reviewdog/action-actionlint`: multi-arch Docker 対応 (v1.65.0+, PR #155)
- `dorny/paths-filter`, `amannn/action-semantic-pull-request` 等: Node.js action (arch 非依存)
- `Bun`: arm64 Linux 公式対応
- `srvaroa/labeler`: amd64 Go バイナリのみ → x64 維持

## Notes

- `pull_request_target` ワークフロー (labeler, semantic, block-merge) は main マージ後に初めて ARM64 ランナーで検証可能。失敗時はホットフィックスで対応
- Flutter が将来 arm64 Linux stable をサポートした場合、analyze/test ジョブも ARM64 移行を検討