### PR TITLE
ci: Gate job を alls-green に移行し Merge Queue 対応を追加

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,9 +11,10 @@ on:
       - opened
       - synchronize
       - reopened
+  merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -179,6 +180,8 @@ jobs:
     permissions: {}
     if: always()
     steps:
-      - name: Check job results
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
-        run: exit 1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+          # パスフィルタ (_changes.yml) でスキップされるジョブを許容
+          allowed-skips: actionlint, format, doc-lint, analyze, test


### PR DESCRIPTION
<!-- copilot:reviewCommentLanguage=ja -->

## チケット

- close #8

## Why

現在の gate job (Pattern B: failure-alert) は機能するが、(1) `merge_group` トリガーがなく Merge Queue に未対応、(2) パスフィルタでスキップされたジョブの扱いが暗黙的、(3) concurrency グループが `merge_group` イベントで壊れる問題がある。

## What

### As Is

- gate job が手動の `contains(needs.*.result, 'failure')` でチェック
- `merge_group` トリガーなし (Merge Queue 未対応)
- concurrency グループが `github.event.pull_request.number` (merge_group で undefined)

### To Be

- gate job を `re-actors/alls-green@v1.2.2` に移行
  - `allowed-skips` でパスフィルタのスキップを明示的に許容
  - skipped vs failure のセマンティクスが明確
- `merge_group` トリガー追加 (Merge Queue 対応)
- concurrency を `github.head_ref || github.ref` パターンに変更
  - PR: ブランチ名で重複実行キャンセル
  - merge_group: 一時ブランチ ref (一意) で互いに干渉しない

## How

- `re-actors/alls-green` は Composite action (bash + python) で ARM64 互換
- SHA ピン留め: `05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe` (v1.2.2)
- 著名 OSS (astral-sh/ruff, tokio-rs/tokio, BurntSushi/ripgrep) でも同一パターンを採用

## Notes

- Merge Queue の Rulesets 設定はこの PR マージ後に手動で実施
  - Settings > Rules > Rulesets > Require merge queue を有効化
  - Merge method: Squash, Build concurrency: 1, Status check timeout: 30min